### PR TITLE
adds snippet type to the url for copy url

### DIFF
--- a/src/components/EditorNav.tsx
+++ b/src/components/EditorNav.tsx
@@ -163,7 +163,7 @@ export default function EditorNav({
           size="sm"
           className="hidden md:flex px-2 text-xs"
           onClick={() => {
-            const url = encodeTextToUrlHash(code)
+            const url = encodeTextToUrlHash(code, snippetType)
             navigator.clipboard.writeText(url)
             alert("URL copied to clipboard!")
           }}

--- a/src/hooks/use-create-snippet-mutation.ts
+++ b/src/hooks/use-create-snippet-mutation.ts
@@ -18,7 +18,12 @@ export const useCreateSnippetMutation = ({
       if (!session) throw new Error("No session")
       const template =
         typeof code === "string"
-          ? { code, type: code.includes("<board") ? "board" : "package" }
+          ? {
+              code,
+              type:
+                urlParams.type ||
+                (code.includes("<board") ? "board" : "package"),
+            }
           : getSnippetTemplate(templateName)
       const {
         data: { snippet },

--- a/src/lib/encodeTextToUrlHash.ts
+++ b/src/lib/encodeTextToUrlHash.ts
@@ -1,7 +1,7 @@
 import { gzipSync, strToU8 } from "fflate"
 import { bytesToBase64 } from "./bytesToBase64"
 
-export function encodeTextToUrlHash(text: string): string {
+export function encodeTextToUrlHash(text: string, type?: string): string {
   // Compress the input string
   const compressedData = gzipSync(strToU8(text))
 
@@ -9,5 +9,6 @@ export function encodeTextToUrlHash(text: string): string {
   const base64Data = bytesToBase64(compressedData)
 
   // Construct the URL
-  return `${window.location.origin}/editor#data:application/gzip;base64,${base64Data}`
+  const typeParam = type ? `&type=${type}` : ""
+  return `${window.location.origin}/editor?${typeParam}#data:application/gzip;base64,${base64Data}`
 }

--- a/src/lib/encodeTextToUrlHash.ts
+++ b/src/lib/encodeTextToUrlHash.ts
@@ -1,7 +1,10 @@
 import { gzipSync, strToU8 } from "fflate"
 import { bytesToBase64 } from "./bytesToBase64"
 
-export function encodeTextToUrlHash(text: string, type?: string): string {
+export function encodeTextToUrlHash(
+  text: string,
+  snippet_type?: string,
+): string {
   // Compress the input string
   const compressedData = gzipSync(strToU8(text))
 
@@ -9,6 +12,6 @@ export function encodeTextToUrlHash(text: string, type?: string): string {
   const base64Data = bytesToBase64(compressedData)
 
   // Construct the URL
-  const typeParam = type ? `&type=${type}` : ""
+  const typeParam = snippet_type ? `&snippet_type=${snippet_type}` : ""
   return `${window.location.origin}/editor?${typeParam}#data:application/gzip;base64,${base64Data}`
 }


### PR DESCRIPTION
Issue: #129

- Updated encodeTextToUrlHash to add snippet type to the URL.
- If not explicitly specified : Defaults to board if <board is detected in code; otherwise package.