### PR TITLE
fix: remove button in view page

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -37,6 +37,7 @@ export const CodeEditor = ({
   initialCode = "",
   manualEditsJson,
   isStreaming = false,
+  showImportAndFormatButtons = true,
 }: {
   onCodeChange: (code: string, filename?: string) => void
   onDtsChange?: (dts: string) => void
@@ -44,6 +45,7 @@ export const CodeEditor = ({
   readOnly?: boolean
   isStreaming?: boolean
   manualEditsJson: string
+  showImportAndFormatButtons?: boolean
 }) => {
   const editorRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
@@ -372,12 +374,14 @@ export const CodeEditor = ({
 
   return (
     <div className="flex flex-col h-full">
-      <CodeEditorHeader
-        currentFile={currentFile}
-        files={files}
-        handleFileChange={handleFileChange}
-        updateFileContent={updateFileContent}
-      />
+      {showImportAndFormatButtons && (
+        <CodeEditorHeader
+          currentFile={currentFile}
+          files={files}
+          handleFileChange={handleFileChange}
+          updateFileContent={updateFileContent}
+        />
+      )}
       <div ref={editorRef} className="flex-1 overflow-auto" />
     </div>
   )

--- a/src/components/PreviewContent.tsx
+++ b/src/components/PreviewContent.tsx
@@ -22,6 +22,7 @@ export interface PreviewContentProps {
   className?: string
   showCodeTab?: boolean
   showJsonTab?: boolean
+  showImportAndFormatButtons?: boolean
   headerClassName?: string
   leftHeaderContent?: React.ReactNode
   isStreaming?: boolean
@@ -39,6 +40,7 @@ export const PreviewContent = ({
   circuitJson,
   showCodeTab = false,
   showJsonTab = true,
+  showImportAndFormatButtons = true,
   className,
   headerClassName,
   leftHeaderContent,
@@ -149,6 +151,7 @@ export const PreviewContent = ({
                   onCodeChange={onCodeChange!}
                   onDtsChange={onDtsChange!}
                   readOnly={readOnly}
+                  showImportAndFormatButtons={showImportAndFormatButtons}
                 />
               </div>
             </TabsContent>

--- a/src/pages/view-snippet.tsx
+++ b/src/pages/view-snippet.tsx
@@ -53,6 +53,7 @@ export const ViewSnippetPage = () => {
                   circuitJson={circuitJson}
                   showCodeTab={true}
                   showJsonTab={false}
+                  showImportAndFormatButtons={false}
                   readOnly
                   headerClassName="p-4 border-b border-gray-200"
                   leftHeaderContent={


### PR DESCRIPTION
View page doesn't need headers

<img width="1089" alt="Screenshot 2024-11-01 at 6 57 53 PM" src="https://github.com/user-attachments/assets/8780ef04-0193-46c3-b3be-881a707c5523">


A quick fix, but I feel in the long run it's not a good approach as it's a prop drilling. We should probably refactor the components to Header outside the CodeEditor.