### PR TITLE
Update link for iframe embedding of snippets

### DIFF
--- a/src/components/ViewSnippetSidebar.tsx
+++ b/src/components/ViewSnippetSidebar.tsx
@@ -116,13 +116,16 @@ export default function ViewSnippetSidebar({
           <div className="text-xs font-medium">Copy embed code</div>
           <div
             className="text-[0.5em] p-2 rounded-sm bg-blue-50 border border-blue-200 cursor-pointer font-mono whitespace-nowrap overflow-hidden text-ellipsis"
-            onClick={() =>
-              copyToClipboard(
-                `<iframe src="https://snippets.tscircuit.com/embed/seveibar/circuitmodule" width="100%" height="100%"></iframe>`,
-              )
-            }
+            onClick={() => {
+              const embedCode = `<iframe src="${window.location.origin}/preview?snippet_id=${snippet?.snippet_id}" width="100%" height="500" frameborder="0"></iframe>`
+              navigator.clipboard.writeText(embedCode)
+              toast({
+                title: "Copied!",
+                description: "Embed code copied to clipboard",
+              })
+            }}
           >
-            {`<iframe src="https://snippets.tscircuit.com/embed/seveibar/circuitmodule" width="100%" height="100%"></iframe>`}
+            {`<iframe src="${window.location.origin}/preview?snippet_id=${snippet?.snippet_id}" width="100%" height="500" frameborder="0"></iframe>`}
           </div>
         </div>
         <div className="space-y-1">


### PR DESCRIPTION
continuation of #171

updated embed link with /preview

<img width="251" alt="image" src="https://github.com/user-attachments/assets/ff442bca-47d1-4386-84bd-81bb9d147881">


cc: @seveibar 