### PR TITLE
fix: cursor-pos

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -152,15 +152,6 @@ export const CodeEditor = ({
         receivedFile: (code: string, path: string) => {
           fsMap.set(path, code)
           env.createFile(path, code)
-          if (viewRef.current) {
-            viewRef.current.dispatch({
-              changes: {
-                from: 0,
-                to: viewRef.current.state.doc.length,
-                insert: viewRef.current.state.doc.toString(),
-              },
-            })
-          }
         },
       },
     }


### PR DESCRIPTION
fixes: #158 

removed unncessary dispatch which causes the editor to update the content of the editor, and makes the cursor go at line 0.

the update happens regardless of whether the content has actually changed.