### PR TITLE
fix: load manual_json

### DIFF
--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -41,12 +41,12 @@ export function CodeAndPreview({ snippet }: Props) {
     )
   }, [])
 
-  // Initialize with template or snippet's manual edits if available
-  const [manualEditsFileContent, setManualEditsFileContent] = useState(
-    snippet?.manual_edits_json ??
-      JSON.stringify(manualEditsTemplate, null, 2) ??
-      "",
-  )
+    // Initialize with template or snippet's manual edits if available
+    const [manualEditsFileContent, setManualEditsFileContent] = useState(
+      snippet?.manual_edits_json ??
+        JSON.stringify(manualEditsTemplate, null, 2) ??
+        "",
+    )
   const [code, setCode] = useState(defaultCode ?? "")
   const [dts, setDts] = useState("")
   const [showPreview, setShowPreview] = useState(true)
@@ -63,6 +63,13 @@ export function CodeAndPreview({ snippet }: Props) {
   }, [Boolean(snippet)])
 
   const { toast } = useToast()
+
+  useEffect(() => {
+    if (snippet?.manual_edits_json) {
+      console.log('Setting manual edits from snippet:', snippet.manual_edits_json);
+      setManualEditsFileContent(snippet.manual_edits_json);
+    }
+  }, [snippet?.manual_edits_json])
 
   const userImports = useMemo(
     () => ({

--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -66,13 +66,9 @@ export function CodeAndPreview({ snippet }: Props) {
 
   useEffect(() => {
     if (snippet?.manual_edits_json) {
-      console.log(
-        "Setting manual edits from snippet:",
-        snippet.manual_edits_json,
-      )
       setManualEditsFileContent(snippet.manual_edits_json)
     }
-  }, [snippet?.manual_edits_json])
+  }, [Boolean(snippet?.manual_edits_json)])
 
   const userImports = useMemo(
     () => ({

--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -41,12 +41,12 @@ export function CodeAndPreview({ snippet }: Props) {
     )
   }, [])
 
-    // Initialize with template or snippet's manual edits if available
-    const [manualEditsFileContent, setManualEditsFileContent] = useState(
-      snippet?.manual_edits_json ??
-        JSON.stringify(manualEditsTemplate, null, 2) ??
-        "",
-    )
+  // Initialize with template or snippet's manual edits if available
+  const [manualEditsFileContent, setManualEditsFileContent] = useState(
+    snippet?.manual_edits_json ??
+      JSON.stringify(manualEditsTemplate, null, 2) ??
+      "",
+  )
   const [code, setCode] = useState(defaultCode ?? "")
   const [dts, setDts] = useState("")
   const [showPreview, setShowPreview] = useState(true)
@@ -66,8 +66,11 @@ export function CodeAndPreview({ snippet }: Props) {
 
   useEffect(() => {
     if (snippet?.manual_edits_json) {
-      console.log('Setting manual edits from snippet:', snippet.manual_edits_json);
-      setManualEditsFileContent(snippet.manual_edits_json);
+      console.log(
+        "Setting manual edits from snippet:",
+        snippet.manual_edits_json,
+      )
+      setManualEditsFileContent(snippet.manual_edits_json)
     }
   }, [snippet?.manual_edits_json])
 


### PR DESCRIPTION
`manualEditsFileContent` wasn;t being initialized with the manual_edit_json when the page loaded, so the issue was when we tried to look for `hasUnsavedChanges` it always resulted in true, and that's the reason it displayed "Unsaved Changes"

fixes: #265 
sorry for this bug too. cc: @seveibar