### PR TITLE
fix: auth generate fails when not using `localhost`

### DIFF
--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -8,7 +8,8 @@ export const useSignIn = () => {
   const setSession = useGlobalStore((s) => s.setSession)
   return () => {
     if (!isUsingFakeApi) {
-      window.location.href = `${snippetsBaseApiUrl}/internal/oauth/github/authorize?next=${window.location.origin}/authorize`
+      const nextUrl = window.location.origin.replace('127.0.0.1', 'localhost')
+      window.location.href = `${snippetsBaseApiUrl}/internal/oauth/github/authorize?next=${nextUrl}/authorize`
     } else {
       setSession({
         account_id: "account-1234",

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -8,7 +8,7 @@ export const useSignIn = () => {
   const setSession = useGlobalStore((s) => s.setSession)
   return () => {
     if (!isUsingFakeApi) {
-      const nextUrl = window.location.origin.replace('127.0.0.1', 'localhost')
+      const nextUrl = window.location.origin.replace("127.0.0.1", "localhost")
       window.location.href = `${snippetsBaseApiUrl}/internal/oauth/github/authorize?next=${nextUrl}/authorize`
     } else {
       setSession({


### PR DESCRIPTION
Fixes the `invalid_code_token ` issue