### PR TITLE
fix: flaky tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@playwright/test"
 
 export default defineConfig({
+  timeout: 60000,
   // Run your local dev server before starting the tests
   webServer: {
     command: "npm run start:playwright-server",


### PR DESCRIPTION
Fixes #346 
/claim #346

### Description:
- I have Ran tests more than 5 times after setting this global timeout of 60 seconds.
![image](https://github.com/user-attachments/assets/b95434f5-b226-4d74-a1a6-b679f2d11839)
