### PR TITLE
fix: align-header on right

### DIFF
--- a/src/components/EditorNav.tsx
+++ b/src/components/EditorNav.tsx
@@ -209,7 +209,7 @@ export default function EditorNav({
           )}
         </div>
       </div>
-      <div className="flex items-center justify-between -space-x-1">
+      <div className="flex items-center justify-end md:justify-between -space-x-1">
         <div className="flex mx-2 items-center space-x-1">
           {snippet && <TypeBadge type={snippetType ?? snippet.snippet_type} />}
           <Button


### PR DESCRIPTION
This works fine for mobile devices but, @seveibar shall i try working on the complete editor page to make it responsive?

![image](https://github.com/user-attachments/assets/2b31a6bd-d3ba-4d8a-bbc8-524c2468b7a8)

fixes: #402 
/claim #402 