### PR TITLE
fix: Use the template at initialization

### DIFF
--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -43,8 +43,11 @@ export function CodeAndPreview({ snippet }: Props) {
   }, [])
 
   // Initialize with template or snippet's manual edits if available
-  const [manualEditsFileContent, setManualEditsFileContent] = useState<string | null>(
-    snippet?.manual_edits_json_content ?? JSON.stringify(manualEditsTemplate, null, 2)
+  const [manualEditsFileContent, setManualEditsFileContent] = useState<
+    string | null
+  >(
+    snippet?.manual_edits_json_content ??
+      JSON.stringify(manualEditsTemplate, null, 2),
   )
   const [code, setCode] = useState(defaultCode ?? "")
   const [dts, setDts] = useState("")

--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -17,6 +17,7 @@ import { useMutation, useQueryClient } from "react-query"
 import EditorNav from "./EditorNav"
 import { PreviewContent } from "./PreviewContent"
 import { parseJsonOrNull } from "@/lib/utils/parseJsonOrNull"
+import manualEditsTemplate from "@/lib/templates/manual-edits-template"
 
 interface Props {
   snippet?: Snippet | null
@@ -42,9 +43,9 @@ export function CodeAndPreview({ snippet }: Props) {
   }, [])
 
   // Initialize with template or snippet's manual edits if available
-  const [manualEditsFileContent, setManualEditsFileContent] = useState<
-    string | null
-  >(null)
+  const [manualEditsFileContent, setManualEditsFileContent] = useState<string | null>(
+    snippet?.manual_edits_json_content ?? JSON.stringify(manualEditsTemplate, null, 2)
+  )
   const [code, setCode] = useState(defaultCode ?? "")
   const [dts, setDts] = useState("")
   const [showPreview, setShowPreview] = useState(true)

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,6 +1,5 @@
 import { useSnippetsBaseApiUrl } from "@/hooks/use-snippets-base-api-url"
 import { basicSetup } from "@/lib/codemirror/basic-setup"
-import manualEditsTemplate from "@/lib/templates/manual-edits-template"
 import { autocompletion } from "@codemirror/autocomplete"
 import { indentWithTab } from "@codemirror/commands"
 import { javascript } from "@codemirror/lang-javascript"


### PR DESCRIPTION
/close #394 

The manual edit template was not getting imported anywhere and because of that the Eval import throws error because of empty string.