### PR TITLE
Revert "fix: Use the template at initialization"

### DIFF
--- a/src/components/CodeAndPreview.tsx
+++ b/src/components/CodeAndPreview.tsx
@@ -17,7 +17,6 @@ import { useMutation, useQueryClient } from "react-query"
 import EditorNav from "./EditorNav"
 import { PreviewContent } from "./PreviewContent"
 import { parseJsonOrNull } from "@/lib/utils/parseJsonOrNull"
-import manualEditsTemplate from "@/lib/templates/manual-edits-template"
 
 interface Props {
   snippet?: Snippet | null
@@ -45,10 +44,7 @@ export function CodeAndPreview({ snippet }: Props) {
   // Initialize with template or snippet's manual edits if available
   const [manualEditsFileContent, setManualEditsFileContent] = useState<
     string | null
-  >(
-    snippet?.manual_edits_json_content ??
-      JSON.stringify(manualEditsTemplate, null, 2),
-  )
+  >(null)
   const [code, setCode] = useState(defaultCode ?? "")
   const [dts, setDts] = useState("")
   const [showPreview, setShowPreview] = useState(true)

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,5 +1,6 @@
 import { useSnippetsBaseApiUrl } from "@/hooks/use-snippets-base-api-url"
 import { basicSetup } from "@/lib/codemirror/basic-setup"
+import manualEditsTemplate from "@/lib/templates/manual-edits-template"
 import { autocompletion } from "@codemirror/autocomplete"
 import { indentWithTab } from "@codemirror/commands"
 import { javascript } from "@codemirror/lang-javascript"


### PR DESCRIPTION
Reverts tscircuit/snippets#413


@imrishabh18 this caused a bug where an Error is shown on every snippet.

I also am not sure that we want to have every snippet require a manual edits file, it should be optional. If it's an empty string/null that means there isn't one set yet



![image](https://github.com/user-attachments/assets/e487827a-6177-4994-b860-5a1a7cc767cb)
