### PR TITLE
fix: import manual edits

### DIFF
--- a/src/hooks/use-run-tsx/index.tsx
+++ b/src/hooks/use-run-tsx/index.tsx
@@ -90,6 +90,12 @@ export const useRunTsx = ({
       }
 
       const __tscircuit_require = (name: string) => {
+        if (
+          name === "./manual-edits.json" &&
+          preSuppliedImports["./manual-edits.json"] === ""
+        ) {
+          return preSuppliedImports["./manual-edits.json"]
+        }
         if (!preSuppliedImports[name]) {
           throw new Error(
             `Import "${name}" not found (imports available: ${Object.keys(preSuppliedImports).join(",")})`,


### PR DESCRIPTION
This is the better approach as we are moving to the "pure snippets", I think we shouldn't be throwing error on importing empty file for manual-edits