### PR TITLE
fix: Responsive Align-header on right #404

### DIFF
--- a/src/components/EditorNav.tsx
+++ b/src/components/EditorNav.tsx
@@ -215,7 +215,7 @@ export default function EditorNav({
           )}
         </div>
       </div>
-      <div className="flex items-center justify-end md:justify-between -space-x-1">
+      <div className="flex items-center justify-end -space-x-1">
         <div className="flex mx-2 items-center space-x-1">
           {snippet && <TypeBadge type={snippetType ?? snippet.snippet_type} />}
           <Button


### PR DESCRIPTION
The EditorNav Component will be aligned to the right side

Responsive device check ✅
<img width="1440" alt="Screenshot 2024-12-25 at 1 25 59 PM" src="https://github.com/user-attachments/assets/80347d1a-03e6-4821-9596-801e7acefdbf" />


/claim #402 